### PR TITLE
Simpler site with dark mode and product details

### DIFF
--- a/catalogues.html
+++ b/catalogues.html
@@ -3,56 +3,55 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title data-i18n="nav.catalogues">Catalogues</title>
-  <link rel="stylesheet" href="styles.css">
+  <title data-i18n="pages.catalogues">Catalogues</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header>
-    <div class="container nav" role="navigation" aria-label="Main">
-      <div class="brand">
-        <div class="logo" aria-hidden="true">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a5 5 0 0 0-5 5v2a5 5 0 1 0 10 0V7a5 5 0 0 0-5-5Zm1 12.9V22h-2v-7.1a7.01 7.01 0 0 1-5.9-5.3h13.8a7.01 7.01 0 0 1-5.9 5.3Z"/></svg>
-        </div>
-        <span>Kentack</span>
-      </div>
-      <nav class="navlinks">
+    <div class="container">
+      <div class="brand"><a href="index.html">Kentack</a></div>
+      <nav>
         <a href="index.html" data-i18n="nav.home">Home</a>
         <a href="catalogues.html" data-i18n="nav.catalogues">Catalogues</a>
         <a href="contact.html" data-i18n="nav.contact">Contact</a>
+        <select id="lang" aria-label="Language">
+          <option value="en">English</option>
+          <option value="ja">日本語</option>
+          <option value="vi">Tiếng Việt</option>
+        </select>
+        <button id="theme-toggle">Dark mode</button>
       </nav>
-      <div class="langpick">
-        <label for="lang" class="sr" aria-live="polite" data-i18n="nav.language">Language</label>
-        <div class="select-wrap">
-          <select id="lang" class="select" aria-label="Language" title="Language">
-            <option value="en">English</option>
-            <option value="ja">日本語</option>
-            <option value="vi">Tiếng Việt</option>
-          </select>
-        </div>
-      </div>
     </div>
   </header>
 
   <main class="container">
-    <h1 data-i18n="nav.catalogues">Catalogues</h1>
-    <p data-i18n="catalog.kicker">Shop by Category</p>
-    <ul style="margin-top:20px">
-      <li data-i18n="cat.drivers">Drivers</li>
-      <li data-i18n="cat.irons">Irons</li>
-      <li data-i18n="cat.putters">Putters</li>
-      <li data-i18n="cat.wedges">Wedges</li>
-      <li data-i18n="cat.balls">Golf Balls</li>
-      <li data-i18n="cat.bags">Bags & Carts</li>
+    <h1 data-i18n="pages.catalogues">Catalogues</h1>
+    <ul class="card-list">
+      <li><button class="catalog-item" data-detail="Low-spin heads, adjustable hosels, tour-proven distance.">Drivers</button></li>
+      <li><button class="catalog-item" data-detail="Forged sets from blades to game-improvement.">Irons</button></li>
+      <li><button class="catalog-item" data-detail="Precision-milled faces for better roll.">Putters</button></li>
+      <li><button class="catalog-item" data-detail="Spin-control designs for scoring shots.">Wedges</button></li>
+      <li><button class="catalog-item" data-detail="Urethane covers for short-game control and speed.">Golf Balls</button></li>
+      <li><button class="catalog-item" data-detail="Lightweight carry, tour stand, and electric carts.">Bags & Carts</button></li>
     </ul>
+    <div id="product-detail" class="hidden"></div>
   </main>
 
   <footer>
-    <div class="container" style="display:flex; justify-content:space-between; align-items:center; gap:12px">
-      <div>© <span id="year"></span> Kentack. <span data-i18n="footer.all">All rights reserved.</span></div>
-      <div style="color:var(--muted)">Made with ♥</div>
+    <div class="container">
+      <div>© <span id="year"></span> Kentack.</div>
     </div>
   </footer>
-
   <script src="i18n.js" defer></script>
+  <script src="script.js" defer></script>
+  <script>
+    document.querySelectorAll('.catalog-item').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const box = document.getElementById('product-detail');
+        box.textContent = btn.dataset.detail;
+        box.classList.remove('hidden');
+      });
+    });
+  </script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -3,59 +3,52 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title data-i18n="contact.title">Contact Kentack</title>
-  <link rel="stylesheet" href="styles.css">
+  <title data-i18n="pages.contact">Contact Kentack</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header>
-    <div class="container nav" role="navigation" aria-label="Main">
-      <div class="brand">
-        <div class="logo" aria-hidden="true">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a5 5 0 0 0-5 5v2a5 5 0 1 0 10 0V7a5 5 0 0 0-5-5Zm1 12.9V22h-2v-7.1a7.01 7.01 0 0 1-5.9-5.3h13.8a7.01 7.01 0 0 1-5.9 5.3Z"/></svg>
-        </div>
-        <span>Kentack</span>
-      </div>
-      <nav class="navlinks">
+    <div class="container">
+      <div class="brand"><a href="index.html">Kentack</a></div>
+      <nav>
         <a href="index.html" data-i18n="nav.home">Home</a>
         <a href="catalogues.html" data-i18n="nav.catalogues">Catalogues</a>
         <a href="contact.html" data-i18n="nav.contact">Contact</a>
+        <select id="lang" aria-label="Language">
+          <option value="en">English</option>
+          <option value="ja">日本語</option>
+          <option value="vi">Tiếng Việt</option>
+        </select>
+        <button id="theme-toggle">Dark mode</button>
       </nav>
-      <div class="langpick">
-        <label for="lang" class="sr" aria-live="polite" data-i18n="nav.language">Language</label>
-        <div class="select-wrap">
-          <select id="lang" class="select" aria-label="Language" title="Language">
-            <option value="en">English</option>
-            <option value="ja">日本語</option>
-            <option value="vi">Tiếng Việt</option>
-          </select>
-        </div>
-      </div>
     </div>
   </header>
 
-  <main class="container contact">
-    <h1 data-i18n="contact.title">Contact Kentack</h1>
-    <p data-i18n="contact.copy">Tell us about your game and we'll match the right gear. Typical reply within 1 business day.</p>
-    <form class="contact-form" style="margin-top:20px">
+  <main class="container">
+    <h1 data-i18n="pages.contact">Contact Kentack</h1>
+    <form class="contact-form">
       <label>
-        <span data-i18n="form.name">Your name</span>
-        <input class="input" type="text">
+        <span data-i18n="contact.name">Your name</span>
+        <input type="text" />
       </label>
       <label>
-        <span data-i18n="form.message">Message</span>
-        <textarea class="input"></textarea>
+        <span data-i18n="contact.email">Email</span>
+        <input type="email" />
       </label>
-      <button class="btn btn-primary" type="submit" data-i18n="form.send">Send</button>
+      <label>
+        <span data-i18n="contact.message">Message</span>
+        <textarea></textarea>
+      </label>
+      <button class="btn" type="submit" data-i18n="contact.send">Send</button>
     </form>
   </main>
 
   <footer>
-    <div class="container" style="display:flex; justify-content:space-between; align-items:center; gap:12px">
-      <div>© <span id="year"></span> Kentack. <span data-i18n="footer.all">All rights reserved.</span></div>
-      <div style="color:var(--muted)">Made with ♥</div>
+    <div class="container">
+      <div>© <span id="year"></span> Kentack.</div>
     </div>
   </footer>
-
   <script src="i18n.js" defer></script>
+  <script src="script.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,276 +4,38 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Kentack • Golf Equipment</title>
-  <meta name="description" content="Kentack — precision golf equipment, catalogues, and accessories." />
-  <link rel="stylesheet" href="styles.css">
-  </head>
+  <link rel="stylesheet" href="styles.css" />
+</head>
 <body>
-  <!-- Header / Navigation -->
   <header>
-    <div class="container nav" role="navigation" aria-label="Main">
-      <div class="brand">
-        <div class="logo" aria-hidden="true">
-          <!-- simple golf tee icon -->
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a5 5 0 0 0-5 5v2a5 5 0 1 0 10 0V7a5 5 0 0 0-5-5Zm1 12.9V22h-2v-7.1a7.01 7.01 0 0 1-5.9-5.3h13.8a7.01 7.01 0 0 1-5.9 5.3Z"/></svg>
-        </div>
-        <span>Kentack</span>
-      </div>
-
-      <nav class="navlinks">
+    <div class="container">
+      <div class="brand"><a href="index.html">Kentack</a></div>
+      <nav>
         <a href="index.html" data-i18n="nav.home">Home</a>
         <a href="catalogues.html" data-i18n="nav.catalogues">Catalogues</a>
         <a href="contact.html" data-i18n="nav.contact">Contact</a>
+        <select id="lang" aria-label="Language">
+          <option value="en">English</option>
+          <option value="ja">日本語</option>
+          <option value="vi">Tiếng Việt</option>
+        </select>
+        <button id="theme-toggle">Dark mode</button>
       </nav>
-
-      <div class="langpick">
-        <label for="lang" class="sr" aria-live="polite" data-i18n="nav.language">Language</label>
-        <div class="select-wrap">
-          <select id="lang" class="select" aria-label="Language" title="Language">
-            <option value="en">English</option>
-            <option value="ja">日本語</option>
-            <option value="vi">Tiếng Việt</option>
-          </select>
-        </div>
-      </div>
     </div>
   </header>
 
-  <!-- Hero -->
-  <main id="home" class="hero">
-    <div class="container hero-inner">
-      <div>
-        <span class="badge" data-i18n="hero.badge">NEW • 2025 LINEUP</span>
-        <h1 class="accent" data-i18n="hero.title">Kentack</h1>
-        <p class="lead" data-i18n="hero.lead">Engineered with tour-grade materials and tuned for consistency. Explore our catalogues to find the perfect fit for your swing.</p>
-        <div class="cta">
-          <a href="catalogues.html" class="btn btn-primary" data-i18n="hero.cta">Browse Catalogues</a>
-          <a href="contact.html" class="btn btn-ghost" data-i18n="hero.secondary">Talk to Sales</a>
-        </div>
-
-        <div class="features">
-          <div class="feature"><svg viewBox="0 0 24 24"><path d="M12 2 2 7l10 5 10-5-10-5Zm0 7L2 4v13l10 5 10-5V4l-10 5Z"/></svg>
-            <div><strong data-i18n="feat.build">Tour‑grade build</strong><div style="color:var(--muted)" data-i18n="feat.build2">Forged faces • Premium shafts</div></div>
-          </div>
-          <div class="feature"><svg viewBox="0 0 24 24"><path d="M12 3a9 9 0 1 0 9 9h-2a7 7 0 1 1-7-7V3Z"/></svg>
-            <div><strong data-i18n="feat.fit">Data‑driven fit</strong><div style="color:var(--muted)" data-i18n="feat.fit2">MOI/loft options • Custom lies</div></div>
-          </div>
-          <div class="feature"><svg viewBox="0 0 24 24"><path d="M4 12h16M12 4v16"/></svg>
-            <div><strong data-i18n="feat.warranty">2‑year warranty</strong><div style="color:var(--muted)" data-i18n="feat.warranty2">Dedicated support</div></div>
-          </div>
-        </div>
-      </div>
-
-      <div class="hero-art" aria-hidden="true">
-        <div class="grid-lines"></div>
-        <!-- Simple club & ball illustration -->
-        <svg class="club" viewBox="0 0 600 400">
-          <!-- club head -->
-          <defs>
-            <linearGradient id="g" x1="0" x2="1">
-              <stop offset="0" stop-color="#1a1d26"/>
-              <stop offset="1" stop-color="#0e1219"/>
-            </linearGradient>
-          </defs>
-          <ellipse cx="400" cy="260" rx="90" ry="48" fill="url(#g)" stroke="#2a2f3a" stroke-width="3"/>
-          <rect x="180" y="240" width="230" height="14" rx="7" fill="#202532"/>
-          <rect x="160" y="242" width="28" height="10" rx="5" fill="#383f4f"/>
-          <!-- ball -->
-          <circle cx="486" cy="240" r="16" fill="#e7ebf2"/>
-          <circle cx="490" cy="244" r="3" fill="#c9ced8"/>
-          <circle cx="482" cy="237" r="3" fill="#c9ced8"/>
-        </svg>
-      </div>
-    </div>
+  <main class="container hero">
+    <h1 data-i18n="pages.home">Welcome to Kentack</h1>
+    <p>Engineered with tour-grade materials and tuned for consistency.</p>
+    <a href="catalogues.html" class="btn" data-i18n="hero.cta">Browse Catalogues</a>
   </main>
 
-  <!-- Catalogues -->
-  <section id="catalogues" aria-label="Catalogues" class="container">
-    <div class="section-heading">
-      <div>
-        <div class="kicker" data-i18n="catalog.kicker">Shop by Category</div>
-        <h2 style="margin:.3rem 0 0">Catalogues</h2>
-      </div>
-      <a href="index.html" class="btn btn-ghost" aria-label="Back to top">↑</a>
-    </div>
-
-    <div class="cards">
-      <!-- Drivers -->
-      <article class="card" id="drivers">
-        <div class="card-media">
-          <span class="chip" data-i18n="catalog.view">View</span>
-          <svg viewBox="0 0 120 90" aria-hidden="true" width="120" height="90">
-            <rect x="8" y="50" width="78" height="10" rx="5" fill="#2a303c"/>
-            <ellipse cx="95" cy="55" rx="18" ry="9" fill="#1e232f"/>
-          </svg>
-        </div>
-        <h3 data-i18n="cat.drivers">Drivers</h3>
-        <p data-i18n="copy.drivers">Low‑spin heads, adjustable hosels, tour‑proven distance.</p>
-      </article>
-
-      <!-- Irons -->
-      <article class="card" id="irons">
-        <div class="card-media">
-          <span class="chip" data-i18n="catalog.view">View</span>
-          <svg viewBox="0 0 120 90" aria-hidden="true" width="120" height="90">
-            <rect x="30" y="40" width="68" height="8" rx="4" fill="#2a303c"/>
-            <rect x="16" y="46" width="18" height="6" rx="3" fill="#383e4d"/>
-          </svg>
-        </div>
-        <h3 data-i18n="cat.irons">Irons</h3>
-        <p data-i18n="copy.irons">Forged feel with consistent gapping across the set.</p>
-      </article>
-
-      <!-- Putters -->
-      <article class="card" id="putters">
-        <div class="card-media">
-          <span class="chip" data-i18n="catalog.view">View</span>
-          <svg viewBox="0 0 120 90" aria-hidden="true" width="120" height="90">
-            <rect x="20" y="44" width="70" height="6" rx="3" fill="#2a303c"/>
-            <rect x="92" y="42" width="14" height="10" rx="3" fill="#1e232f"/>
-          </svg>
-        </div>
-        <h3 data-i18n="cat.putters">Putters</h3>
-        <p data-i18n="copy.putters">Blade and mallet shapes with balanced strokes.</p>
-      </article>
-
-      <!-- Wedges -->
-      <article class="card" id="wedges">
-        <div class="card-media">
-          <span class="chip" data-i18n="catalog.view">View</span>
-          <svg viewBox="0 0 120 90" aria-hidden="true" width="120" height="90">
-            <rect x="20" y="48" width="68" height="8" rx="4" fill="#2a303c"/>
-            <circle cx="95" cy="50" r="8" fill="#1e232f"/>
-          </svg>
-        </div>
-        <h3 data-i18n="cat.wedges">Wedges</h3>
-        <p data-i18n="copy.wedges">Grinds for every turf condition and shot window.</p>
-      </article>
-
-      <!-- Balls -->
-      <article class="card" id="balls">
-        <div class="card-media">
-          <span class="chip" data-i18n="catalog.view">View</span>
-          <svg viewBox="0 0 120 90" aria-hidden="true" width="120" height="90">
-            <circle cx="60" cy="46" r="14" fill="#e7ebf2"/>
-            <circle cx="56" cy="44" r="2" fill="#c9ced8"/>
-            <circle cx="64" cy="49" r="2" fill="#c9ced8"/>
-          </svg>
-        </div>
-        <h3 data-i18n="cat.balls">Golf Balls</h3>
-        <p data-i18n="copy.balls">Urethane covers for short‑game control and speed.</p>
-      </article>
-
-      <!-- Bags & Carts -->
-      <article class="card" id="bags">
-        <div class="card-media">
-          <span class="chip" data-i18n="catalog.view">View</span>
-          <svg viewBox="0 0 120 90" aria-hidden="true" width="120" height="90">
-            <rect x="40" y="30" width="24" height="34" rx="6" fill="#2a303c"/>
-            <rect x="36" y="28" width="32" height="6" rx="3" fill="#383e4d"/>
-          </svg>
-        </div>
-        <h3 data-i18n="cat.bags">Bags & Carts</h3>
-        <p data-i18n="copy.bags">Lightweight carry, tour stand, and electric carts.</p>
-      </article>
-
-      <!-- Gloves & Accessories -->
-      <article class="card" id="gloves">
-        <div class="card-media">
-          <span class="chip" data-i18n="catalog.view">View</span>
-          <svg viewBox="0 0 120 90" aria-hidden="true" width="120" height="90">
-            <rect x="42" y="34" width="30" height="26" rx="6" fill="#2a303c"/>
-            <rect x="74" y="36" width="10" height="10" rx="3" fill="#383e4d"/>
-          </svg>
-        </div>
-        <h3 data-i18n="cat.gloves">Gloves & Accessories</h3>
-        <p data-i18n="copy.gloves">Premium leather gloves, towels, and rangefinders.</p>
-      </article>
-
-      <!-- Apparel -->
-      <article class="card" id="apparel">
-        <div class="card-media">
-          <span class="chip" data-i18n="catalog.view">View</span>
-          <svg viewBox="0 0 120 90" aria-hidden="true" width="120" height="90">
-            <rect x="28" y="30" width="64" height="28" rx="8" fill="#2a303c"/>
-            <rect x="40" y="58" width="40" height="10" rx="5" fill="#383e4d"/>
-          </svg>
-        </div>
-        <h3 data-i18n="cat.apparel">Apparel</h3>
-        <p data-i18n="copy.apparel">Breathable polos, weatherproof layers, and hats.</p>
-      </article>
-
-      <!-- Shoes -->
-      <article class="card" id="shoes">
-        <div class="card-media">
-          <span class="chip" data-i18n="catalog.view">View</span>
-          <svg viewBox="0 0 120 90" aria-hidden="true" width="120" height="90">
-            <rect x="24" y="54" width="72" height="12" rx="6" fill="#2a303c"/>
-            <rect x="20" y="50" width="30" height="10" rx="5" fill="#383e4d"/>
-          </svg>
-        </div>
-        <h3 data-i18n="cat.shoes">Shoes</h3>
-        <p data-i18n="copy.shoes">Spiked and spikeless options for any course.</p>
-      </article>
-
-      <!-- Training Aids -->
-      <article class="card" id="training">
-        <div class="card-media">
-          <span class="chip" data-i18n="catalog.view">View</span>
-          <svg viewBox="0 0 120 90" aria-hidden="true" width="120" height="90">
-            <rect x="28" y="30" width="64" height="8" rx="4" fill="#2a303c"/>
-            <circle cx="92" cy="34" r="6" fill="#383e4d"/>
-          </svg>
-        </div>
-        <h3 data-i18n="cat.training">Training Aids</h3>
-        <p data-i18n="copy.training">Swing tempo trainers, putting mats, and nets.</p>
-      </article>
-    </div>
-  </section>
-
-  <!-- Contact -->
-  <section id="contact" aria-label="Contact" class="container">
-    <div class="section-heading">
-      <div>
-        <div class="kicker" data-i18n="contact.kicker">We'd love to help</div>
-        <h2 data-i18n="contact.title">Contact Kentack</h2>
-      </div>
-    </div>
-
-    <div class="contact">
-      <form class="panel" aria-labelledby="contact-title" onsubmit="event.preventDefault(); alert(currentText('contact.toast'));">
-        <div style="display:grid; grid-template-columns:1fr 1fr; gap:12px">
-          <div>
-            <label for="name" data-i18n="form.name">Your name</label>
-            <input id="name" class="input" placeholder="" />
-          </div>
-          <div>
-            <label for="email">Email</label>
-            <input id="email" class="input" type="email" placeholder="name@example.com" />
-          </div>
-        </div>
-        <div style="margin-top:12px">
-          <label for="msg" data-i18n="form.message">Message</label>
-          <textarea id="msg" class="input" placeholder=""></textarea>
-        </div>
-        <div style="display:flex; justify-content:end; margin-top:12px">
-          <button class="btn btn-primary" type="submit" data-i18n="form.send">Send</button>
-        </div>
-      </form>
-
-      <aside class="panel">
-        <h3 style="margin:0 0 10px" data-i18n="contact.sales">Sales & Support</h3>
-        <p style="color:var(--muted)" data-i18n="contact.copy">Tell us about your game and we'll match the right gear. Typical reply within 1 business day.</p>
-        <p>📞 <a href="tel:+1-800-KENTACK">+1‑800‑KENTACK</a><br/>✉️ <a href="mailto:sales@kentack.example">sales@kentack.example</a></p>
-      </aside>
-    </div>
-  </section>
-
   <footer>
-    <div class="container" style="display:flex; justify-content:space-between; align-items:center; gap:12px">
-      <div>© <span id="year"></span> Kentack. <span data-i18n="footer.all">All rights reserved.</span></div>
-      <div style="color:var(--muted)">Made with ♥</div>
+    <div class="container">
+      <div>© <span id="year"></span> Kentack.</div>
     </div>
   </footer>
   <script src="i18n.js" defer></script>
+  <script src="script.js" defer></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const body = document.body;
+  const btn = document.getElementById('theme-toggle');
+  if (btn) {
+    const stored = localStorage.getItem('theme') || 'light';
+    body.dataset.theme = stored;
+    btn.textContent = stored === 'dark' ? 'Light mode' : 'Dark mode';
+    btn.addEventListener('click', () => {
+      const newTheme = body.dataset.theme === 'dark' ? 'light' : 'dark';
+      body.dataset.theme = newTheme;
+      btn.textContent = newTheme === 'dark' ? 'Light mode' : 'Dark mode';
+      localStorage.setItem('theme', newTheme);
+    });
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,127 +1,111 @@
-    :root{
-      --bg:#0b0b0f;          /* near-black */
-      --card:#111218;        /* dark panel */
-      --muted:#9aa3b2;       /* muted text */
-      --text:#f5f7fb;        /* primary text */
-      --accent:#ffd400;      /* yellow brand */
-      --accent-2:#ffe866;    /* soft yellow */
-      --ring: rgba(255, 212, 0, .35);
-      --ok:#38d39f;
-      --warn:#ffb020;
-      --err:#ff6b6b;
-      --shadow: 0 10px 30px rgba(0,0,0,.45), 0 2px 8px rgba(0,0,0,.6);
-      --radius: 20px;
-      --radius-sm: 12px;
-      --container: 1200px;
-    }
+:root {
+  --bg: #ffffff;
+  --text: #111111;
+  --link: #006400;
+  --border: #cccccc;
+}
 
-    /* Base --------------------------------------------------------------- */
-    *{ box-sizing: border-box }
-    html{ scroll-behavior: smooth; }
-    body{
-      margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
-      color: var(--text); background: radial-gradient(1200px 600px at 80% -10%, rgba(255,212,0,.08), transparent 50%),
-                           radial-gradient(1000px 500px at -10% 10%, rgba(255,232,102,.06), transparent 50%),
-                           var(--bg);
-      line-height: 1.55;
-    }
-    a{ color: var(--accent); text-decoration: none }
-    img{ max-width:100%; height:auto; display:block }
-    .container{ width:min(100%, var(--container)); margin-inline:auto; padding-inline: 24px }
+[data-theme="dark"] {
+  --bg: #111111;
+  --text: #eeeeee;
+  --link: #90ee90;
+  --border: #444444;
+}
 
-    /* Header ------------------------------------------------------------- */
-    header{
-      position: sticky; top:0; z-index: 50; backdrop-filter: saturate(1.1) blur(10px);
-      background: rgba(10,10,14,.65); border-bottom: 1px solid rgba(255,255,255,.06);
-    }
-    .nav{ display:flex; align-items:center; justify-content:space-between; gap: 16px; height:72px }
-    .brand{ display:flex; align-items:center; gap:12px; font-weight:800; letter-spacing:.3px; font-size: 1.1rem }
-    .logo{ width:36px; height:36px; border-radius: 12px; background: linear-gradient(145deg, var(--accent), var(--accent-2));
-           box-shadow: inset 0 0 0 2px rgba(0,0,0,.25), 0 8px 18px rgba(255,212,0,.25); display:grid; place-items:center }
-    .logo svg{ width:22px; height:22px; fill:#111 }
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
 
-    .navlinks{ display:flex; gap: 18px; align-items:center }
-    .navlinks a{ color: var(--text); opacity:.85; padding:8px 12px; border-radius:10px; transition:.2s ease }
-    .navlinks a:hover{ opacity:1; background: rgba(255,255,255,.06) }
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
 
-    .langpick{ display:flex; align-items:center; gap:10px }
-    .select{ appearance:none; background:#0e1016; color:var(--text); border:1px solid rgba(255,212,0,.55);
-             padding:10px 40px 10px 12px; border-radius: 12px; font-weight:600; position:relative; box-shadow: 0 0 0 0 rgba(0,0,0,0) }
-    .select:focus{ outline:none; border-color: var(--accent); box-shadow: 0 0 0 4px var(--ring) }
-    .select-wrap{ position:relative }
-    .select-wrap::after{ content:"▾"; position:absolute; right:12px; top:50%; translate:0 -50%; pointer-events:none; opacity:.7; color: var(--accent) }
-    /* Ensure dropdown list is also dark on supporting browsers */
-    .select option{ background:#0b0b0f; color:var(--text) }
+header {
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 0;
+}
 
-    /* Hero --------------------------------------------------------------- */
-    .hero{ position: relative; padding: 64px 0 40px }
-    .hero-inner{ display:grid; grid-template-columns: 1.2fr .8fr; gap: 32px; align-items:center }
-    .badge{ display:inline-flex; gap:8px; align-items:center; background:rgba(255,212,0,.10); color:#111; padding:6px 10px; border-radius: 999px;
-            font-weight:700; letter-spacing:.2px; border:1px solid rgba(255,212,0,.35); color: var(--accent) }
-    h1{ font-size: clamp(2rem, 4.6vw, 4rem); line-height:1.05; margin: 14px 0 10px; letter-spacing:.2px }
-    .accent{ background: linear-gradient(90deg, var(--accent), #fff099 60%); -webkit-background-clip: text; background-clip: text; color: transparent }
-    .lead{ font-size: clamp(1rem, 1.2vw, 1.15rem); color: var(--muted); max-width: 55ch }
+header .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
 
-    .cta{ display:flex; gap:12px; margin-top: 22px }
-    .btn{ --h: 48px; display:inline-flex; height: var(--h); align-items:center; justify-content:center; padding: 0 18px; gap:10px;
-          border-radius: 14px; font-weight:800; letter-spacing:.2px; border:1px solid rgba(255,255,255,.12); box-shadow: var(--shadow);
-          transition: transform .12s ease, background .2s ease, border-color .2s ease }
-    .btn-primary{ background: linear-gradient(180deg, var(--accent), var(--accent-2)); color:#111; border-color: rgba(255,212,0,.6) }
-    .btn-primary:hover{ transform: translateY(-1px) }
-    .btn-ghost{ background: rgba(255,255,255,.06); color: var(--text) }
-    .btn-ghost:hover{ background: rgba(255,255,255,.1) }
+nav a {
+  margin-right: 1rem;
+  color: var(--text);
+  text-decoration: none;
+}
 
-    .hero-art{ position:relative; aspect-ratio: 4/3; border-radius: var(--radius); background: radial-gradient(600px 300px at 30% 10%, rgba(255,212,0,.25), transparent 40%),
-               linear-gradient(160deg, #0f1016, #191b24); border:1px solid rgba(255,255,255,.08); box-shadow: var(--shadow);
-               display:grid; place-items:center; overflow:hidden }
-    .grid-lines{ position:absolute; inset:0; background-image: linear-gradient(rgba(255,255,255,.06) 1px, transparent 1px),
-                 linear-gradient(90deg, rgba(255,255,255,.06) 1px, transparent 1px);
-                 background-size: 36px 36px; mask: radial-gradient(500px 260px at 70% 30%, black, transparent 70%) }
-    .club{ width: 74%; filter: drop-shadow(0 18px 40px rgba(0,0,0,.55)) }
+nav a:last-child {
+  margin-right: 0;
+}
 
-    /* Feature row -------------------------------------------------------- */
-    .features{ display:grid; grid-template-columns: repeat(3, 1fr); gap:16px; margin-top:30px }
-    .feature{ background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.03)); border:1px solid rgba(255,255,255,.08);
-              border-radius: 16px; padding:16px; display:flex; gap:12px; align-items:center }
-    .feature svg{ width:26px; height:26px; flex: 0 0 auto; fill: var(--accent) }
+#theme-toggle {
+  margin-left: 1rem;
+  border: 1px solid var(--text);
+  background: none;
+  color: var(--text);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+}
 
-    /* Catalogues --------------------------------------------------------- */
-    section{ padding: 64px 0 }
-    .section-heading{ display:flex; align-items:end; justify-content:space-between; gap:16px; margin-bottom:18px }
-    .kicker{ color: var(--accent); font-weight:800; letter-spacing:.3px }
+.hero {
+  text-align: center;
+  padding: 2rem 0;
+}
 
-    .cards{ display:grid; grid-template-columns: repeat(12, 1fr); gap: 16px }
-    .card{ grid-column: span 4; background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.03)); border:1px solid rgba(255,255,255,.08);
-           border-radius: var(--radius-sm); overflow:hidden; position:relative; transition: transform .14s ease, border-color .2s ease }
-    .card:hover{ transform: translateY(-4px); border-color: var(--ring) }
-    .card-media{ aspect-ratio: 4/3; background: radial-gradient(400px 180px at 70% 0%, rgba(255,212,0,.18), transparent 40%), #0f1117; display:grid; place-items:center; overflow:hidden }
-    .card h3{ margin: 10px 14px 0; font-size: 1.1rem }
-    .card p{ margin: 6px 14px 14px; color: var(--muted); font-size: .95rem }
-    .chip{ position:absolute; top:10px; left:10px; padding:6px 10px; background: rgba(255,212,0,.12); border:1px solid rgba(255,212,0,.35); color: var(--accent);
-           border-radius: 999px; font-weight:700; letter-spacing:.3px; font-size:.8rem }
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--text);
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--text);
+  background: none;
+}
 
-    /* Contact ------------------------------------------------------------ */
-    .contact{ display:grid; grid-template-columns: 1fr 1fr; gap: 24px }
-    .panel{ background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.03)); border:1px solid rgba(255,255,255,.08);
-            border-radius: var(--radius); padding: 18px; box-shadow: var(--shadow) }
-    .input{ width:100%; background: #0e1016; color: var(--text); border:1px solid rgba(255,255,255,.12); border-radius: 12px; padding: 12px 14px; outline:none }
-    .input:focus{ border-color: var(--ring); box-shadow: 0 0 0 4px rgba(255,212,0,.12) }
-    textarea.input{ min-height: 130px; resize: vertical }
+.card-list {
+  list-style: none;
+  padding: 0;
+}
 
-    /* Anchor offset so sticky header doesn't cover targets */
-    [id]{ scroll-margin-top: 84px }
+.card-list li {
+  margin: 0.5rem 0;
+}
 
-    /* Footer ------------------------------------------------------------- */
-    footer{ padding: 36px 0 56px; color: var(--muted); border-top:1px solid rgba(255,255,255,.06) }
+#product-detail {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
 
-    /* Responsive --------------------------------------------------------- */
-    @media (max-width: 980px){ .hero-inner{ grid-template-columns: 1fr; } .contact{ grid-template-columns:1fr } }
-    @media (max-width: 840px){ .card{ grid-column: span 6 } }
-    @media (max-width: 560px){ .card{ grid-column: span 12 } .navlinks{ display:none } }
+.hidden {
+  display: none;
+}
 
-    /* Motion preferences (accessibility) -------------------------------- */
-    @media (prefers-reduced-motion: reduce){
-      *{ animation: none !important; transition: none !important }
-    }
+input, textarea, select {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--text);
+}
 
-  .sr{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0 }
+label {
+  display: block;
+  margin: 0.5rem 0;
+}
+
+button {
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- streamline site layout and styling
- add light/dark theme toggle persisted across pages
- show product details when clicking catalogue entries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d61051448322ba58a5f43c9df837