### PR TITLE
Simplify site layout

### DIFF
--- a/catalogues.html
+++ b/catalogues.html
@@ -14,12 +14,6 @@
         <a href="index.html" data-i18n="nav.home">Home</a>
         <a href="catalogues.html" data-i18n="nav.catalogues">Catalogues</a>
         <a href="contact.html" data-i18n="nav.contact">Contact</a>
-        <select id="lang" aria-label="Language">
-          <option value="en">English</option>
-          <option value="ja">日本語</option>
-          <option value="vi">Tiếng Việt</option>
-        </select>
-        <button id="theme-toggle">Dark mode</button>
       </nav>
     </div>
   </header>

--- a/contact.html
+++ b/contact.html
@@ -14,12 +14,6 @@
         <a href="index.html" data-i18n="nav.home">Home</a>
         <a href="catalogues.html" data-i18n="nav.catalogues">Catalogues</a>
         <a href="contact.html" data-i18n="nav.contact">Contact</a>
-        <select id="lang" aria-label="Language">
-          <option value="en">English</option>
-          <option value="ja">日本語</option>
-          <option value="vi">Tiếng Việt</option>
-        </select>
-        <button id="theme-toggle">Dark mode</button>
       </nav>
     </div>
   </header>
@@ -39,7 +33,7 @@
         <span data-i18n="contact.message">Message</span>
         <textarea></textarea>
       </label>
-      <button class="btn" type="submit" data-i18n="contact.send">Send</button>
+      <button type="submit" data-i18n="contact.send">Send</button>
     </form>
   </main>
 

--- a/index.html
+++ b/index.html
@@ -14,20 +14,14 @@
         <a href="index.html" data-i18n="nav.home">Home</a>
         <a href="catalogues.html" data-i18n="nav.catalogues">Catalogues</a>
         <a href="contact.html" data-i18n="nav.contact">Contact</a>
-        <select id="lang" aria-label="Language">
-          <option value="en">English</option>
-          <option value="ja">日本語</option>
-          <option value="vi">Tiếng Việt</option>
-        </select>
-        <button id="theme-toggle">Dark mode</button>
       </nav>
     </div>
   </header>
 
-  <main class="container hero">
+  <main class="container">
     <h1 data-i18n="pages.home">Welcome to Kentack</h1>
     <p>Engineered with tour-grade materials and tuned for consistency.</p>
-    <a href="catalogues.html" class="btn" data-i18n="hero.cta">Browse Catalogues</a>
+    <p><a href="catalogues.html" data-i18n="hero.cta">Browse Catalogues</a></p>
   </main>
 
   <footer>

--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,7 @@
 :root {
   --bg: #ffffff;
   --text: #111111;
-  --link: #006400;
   --border: #cccccc;
-}
-
-[data-theme="dark"] {
-  --bg: #111111;
-  --text: #eeeeee;
-  --link: #90ee90;
-  --border: #444444;
 }
 
 body {
@@ -27,7 +19,6 @@ body {
 }
 
 header {
-  border-bottom: 1px solid var(--border);
   padding: 0.5rem 0;
 }
 
@@ -39,36 +30,14 @@ header .container {
 
 nav a {
   margin-right: 1rem;
-  color: var(--text);
-  text-decoration: none;
 }
 
 nav a:last-child {
   margin-right: 0;
 }
 
-#theme-toggle {
-  margin-left: 1rem;
-  border: 1px solid var(--text);
-  background: none;
-  color: var(--text);
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-}
-
-.hero {
-  text-align: center;
+main {
   padding: 2rem 0;
-}
-
-.btn {
-  display: inline-block;
-  padding: 0.5rem 1rem;
-  border: 1px solid var(--text);
-  border-radius: 4px;
-  text-decoration: none;
-  color: var(--text);
-  background: none;
 }
 
 .card-list {
@@ -91,7 +60,7 @@ nav a:last-child {
   display: none;
 }
 
-input, textarea, select {
+input, textarea {
   width: 100%;
   padding: 0.5rem;
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Remove language selector and dark mode button from page headers for a cleaner interface
- Simplify home page markup with basic link-based call to action
- Trim CSS to minimal rules and drop unused theme and button styling

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a6d809c56c8322819fef0fa5ff6cdb